### PR TITLE
Edits to address rendering of individual stocks and stock scraping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
     ntlm-http (0.1.1)
     pg (1.2.3)
     pmap (1.1.1)
@@ -263,6 +265,7 @@ GEM
 
 PLATFORMS
   -darwin-20
+  x86_64-darwin-18
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -1,14 +1,22 @@
+require 'pry'
+
 class StocksController < ApplicationController
   def index
-    stock = Stock.all.order(name: :asc)
-    render json: stock
+    stocks = Stock.all.order(name: :asc)
+    render json: stocks
+    # ^ Just renaming for clarity.
   end
 
   def create
   end
 
+  def new
+  end
+
   def show
-      render json: stock
+    # binding.pry
+    # Using your original code, if you put a binding.pry here, you can see that the endpoint isn't being hit yet when visiting the http://localhost:3000/stock/1 page.
+    render json: stock
   end
   
   private
@@ -16,5 +24,4 @@ class StocksController < ApplicationController
     def stock
       @stock = Stock.find(params[:id])
     end
-
 end

--- a/app/controllers/stocks_data_controller.rb
+++ b/app/controllers/stocks_data_controller.rb
@@ -1,12 +1,30 @@
+require 'pry'
+# This require is - ahem- required to use binding.pry. You'd have to add it to the top of every file that you want to use pry in.
+
 class StocksDataController < ApplicationController
   def index
   end
 
   def scrape
-    StockData.crawl! #(:parse, url: "https://www.example.com/")
+    # binding.pry
+    # Putting a binding.pry here helps you to see in the terminal what the response of this method is.
+    # If you're not already using byebug (which I'm not familiar with really), then I'd suggest using pry as a method of debugging the Ruby stuff.
+    # https://learn.co/lessons/debugging-with-pry
+    # scrape returns:
+    # => {:spider_name=>"stock_data",
+    #   :status=>:completed,
+    #   :error=>nil,
+    #   :environment=>"development",
+    #   :start_time=>2021-03-20 17:10:19 -0400,
+    #   :stop_time=>2021-03-20 17:10:21 -0400,
+    #   :running_time=>1.633,
+    #   :visits=>{:requests=>1, :responses=>1},
+    #   :items=>{:sent=>0, :processed=>0},
+    #   :events=>{:requests_errors=>{}, :drop_items_errors=>{}, :custom=>{}}}
+
+    scraped_data = StockData.crawl! #(:parse, url: "https://www.example.com/")
+    render json:scraped_data
+    # ^ The addition of this line was needed.
+    # The beginning of this article has a little more on this change to serving JSON to the client: https://dev.to/norrischebl/using-rails-api-with-react-4cg0
   end
-
 end
-
-
-

--- a/app/javascript/components/Stock/Stock.jsx
+++ b/app/javascript/components/Stock/Stock.jsx
@@ -1,22 +1,34 @@
-import React, {useState, useEffect} from "react";
-import { Link } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
+
+// Your components dont need to be nested inside folders. For example, this file is components/Stock/Stock.jsx. This could be components/Stock.jsx.
 
 function Stock() {
   const [stock, setStock] = useState([]);
 
-  useEffect((id) => {
-    fetch(`stocks/show/${id}`)
-      .then(response => response.json())
-      .then(data => setStock(data))
-      /*.catch(() => history.push('/'))*/;
+  // You have the id from react-router. So you just need to grab the id from the react-router params. You can use the useParams hook to do that.
+  // More here: https://reactrouter.com/web/example/url-params
+
+  const { id } = useParams();
+  console.log(id);
+
+  useEffect(() => {
+    // Using your original code, if you put a console.log here, you can see that id is undefined.
+    console.log(id);
+    fetch(`/show/${id}`)
+      // The path should be ^ rather than stocks/show/${id}. I knew this because of the `get '/show/:id', to: 'stocks#show'` in your routes.rb file.
+      .then((response) => response.json())
+      .then((data) => setStock(data));
+    /*.catch(() => history.push('/'))*/
   }, []);
 
   return (
     <div>
       <h1>SCL</h1>
-      <div>{ stock.name }</div>
+      <div>{stock.name}</div>
       <Link to="/">Home</Link>
     </div>
   );
 }
+
 export default Stock;

--- a/app/javascript/components/StockData/StockData.jsx
+++ b/app/javascript/components/StockData/StockData.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 function StockInfo() {
-  const [stockPrice, setStockPrice] = useState('');
+  const [stockPrice, setStockPrice] = useState("");
   /*const onSubmit = () => {
     const url = "stock_data/new";
     fetch(url)
@@ -17,34 +17,57 @@ function StockInfo() {
       method: 'get',
       headers: {'Content-Type': 'application/json'},
       /*body: JSON.stringify()*/
-      /*.then(console.log())*/
-      /*.then(console.log('OK'))*/
-      /*.catch(error => console.log(error.message));*/
+  /*.then(console.log())*/
+  /*.then(console.log('OK'))*/
+  /*.catch(error => console.log(error.message));*/
   /*  })
     .then(response => response.json())
     .then(data => setStockPrice(data))
   }, []);*/
 
   const handleClick = () => {
-    fetch('stocks_data/scrape', {
-      method: 'get',
-      headers: {'Content-Type': 'application/json'},
-      /*body: JSON.stringify()*/
-      /*.then(console.log())*/
-      /*.then(console.log('OK'))*/
-      /*.catch(error => console.log(error.message));*/
-    })
-    .then(response => response.json())
-    .then(data => setStockPrice(data))
+    fetch("stocks_data/scrape")
+      // A GET is the default method for fetch requests. See here: https://github.github.io/fetch/.
+      // The result of the scrape endpoint (the response.json()) is:
+      // {
+      //   "spider_name": "stock_data",
+      //   "status": "completed",
+      //   "error": null,
+      //   "environment": "development",
+      //   "start_time": "2021-03-20T17:47:09.976-04:00",
+      //   "stop_time": "2021-03-20T17:47:10.274-04:00",
+      //   "running_time": 0.298,
+      //   "visits": {
+      //       "requests": 1,
+      //       "responses": 1
+      //   },
+      //   "items": {
+      //       "sent": 0,
+      //       "processed": 0
+      //   },
+      //   "events": {
+      //       "requests_errors": {},
+      //       "drop_items_errors": {},
+      //       "custom": {}
+      //   }
+      // }
+      // And the result of the scrape is not stock-specific, is it? I'm not sure what you want to display in the return for this page, other than the "Scrape" button.
+      // I see the "stockPrice" in a div below to be rendered, but I don't see how this fetch call returns a response for setting that value.
+      // You could flash a message or something that says something along the lines of "Scrape successful/failed" and/or redirect to the homepage or something. At least as a first pass?
+      .then((response) => response.json())
+      .then((data) => console.log(data));
+    // With these changes, you can see your result in the console!
   };
-  
+
   return (
     <div>
       <h1>Stock Data</h1>
       {/*<button onClick = {() => { onSubmit() }}>Scrape data</button><br />*/}
       <div>
         <button onClick={handleClick}>Scrape!</button>
-        <div>{stockPrice}</div>
+        {stockPrice && <div>{stockPrice}</div>}
+        {/* Doing this ^ (with the brackets and &&) means that the div for the stockPrice only appears when there's a value for it. 
+        Otherwise, without this, you just have an empty div on your page. Which isn't terrible, but isn't desirable. */}
       </div>
       <br />
       <Link to="/">Home</Link>
@@ -52,5 +75,3 @@ function StockInfo() {
   );
 }
 export default StockInfo;
-
-

--- a/app/javascript/routes/Index.jsx
+++ b/app/javascript/routes/Index.jsx
@@ -10,9 +10,10 @@ export default (
     <Switch>
       <Route path="/" exact component={Home} />
       <Route path="/stocks" exact component={Stocks} />
-      <Route path="/stock/:id" exact component={Stock} />
+      <Route path="/stocks/:id" exact component={Stock} />
+      {/* # The page we should be visiting is http://localhost:3000/stocks/1
+      This wasn't broken, but I believe it's a better practice to nest like ^*/}
       <Route path="/stockdata" exact component={StockData} />
     </Switch>
   </Router>
 );
- 

--- a/app/models/stock_data.rb
+++ b/app/models/stock_data.rb
@@ -24,7 +24,4 @@ class StockData < Kimurai::Base
     #   Stock.where(item).first
     # end
   end
-
-
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,3 +7,15 @@ Rails.application.routes.draw do
   root 'home#index'
   get '/*path' => 'home#index'
 end
+
+# I think you may want to consider namespacing these routes within api (v1). Your controllers would also need to be namespaced accordingly.
+# Consider something that would look more like this for stocks:
+# Rails.application.routes.draw do
+#   namespace :api do
+#     resources :stocks, only: %i[index show create destroy update]
+#   end
+# end
+
+# See for more info:
+# https://hibbard.eu/rails-react-crud-app/
+# https://pamit.medium.com/todo-list-building-a-react-app-with-rails-api-7a3027907665


### PR DESCRIPTION
Branched off of "scrape-data" to suggest some changes to address the following issues. I tried to include lotsa comments as to why I made certain changes.

> 1. Rendering of individual stocks (Link: http://localhost:3000/stock/:id): The console returns: Uncaught (in promise) SyntaxError: Unexpected token < in JSON at position 0 and I can’t quite figure out why because my code is very similar to the code for 		rendering all stocks, for which I’m not having any errors.

> 2. Getting the actual stock data (Link: http://localhost:3000/stockdata): I would like to get the data on click on the button “Scrape” but the Chrome console returns: Uncaught (in promise) SyntaxError: Unexpected end of JSON input at StockData.jsx:37 and I get No template found for StocksDataController#scrape, rendering head :no_content on my terminal, which, if I understand correctly, means that it manages to get the data, but it doesn’t know how to render it, but I’m not sure.

@laureen-m Feel free to use this code (or not) as you see fit!

The debugging take aways (I use them as much as possible) are binding.pry for Ruby code, and console.logs for the JS code.